### PR TITLE
fix ssl/tls settings so it actually works.

### DIFF
--- a/lib/XeroOAuth.php
+++ b/lib/XeroOAuth.php
@@ -261,7 +261,10 @@ class XeroOAuth {
 						'curlHeader' 
 				),
 				CURLOPT_HEADER => FALSE,
-				CURLINFO_HEADER_OUT => TRUE 
+				CURLINFO_HEADER_OUT => TRUE,
+				CURLOPT_SSL_CIPHER_LIST => 'TLSv1',
+                                CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1,
+                                CURLOPT_USE_SSL => CURLUSESSL_ALL
 		) );
 		
 		if ($this->config ['application_type'] == "Partner") {


### PR DESCRIPTION
on some web hosting environments you get an error similar to:

"Curl error: SSL certificate problem, verify that the CA cert is OK"

I have a feeling this is something to do with POODLE?

Anyway, adding these settings to curl makes it work.
